### PR TITLE
empty cache after emitting event

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,8 +50,10 @@ class iSpindel(SensorActive):
 				if cache[self.key] is not None:
 					if self.sensorType == "Gravity":
 						reading = calcGravity(self.tuningPolynom, cache[self.key]['Angle'], self.unitsGravity)
+						del cache[self.key]['Angle']
 					else:
 						reading = cache[self.key][self.sensorType]
+						del cache[self.key][self.sensorType]
 					self.data_received(reading)
 			except:
 				pass


### PR DESCRIPTION
The iSpindel plugin spammed my logfile HARD by calling `self.data_received(reading)` over 100 times a second per sensor. This resulted in 300MB big logfiles for 24h.

The thing is: once the api writes to the cache nothing removes it from the cache so the def `execute(self):` function triggers on it on every call and always emits an event via `self.data_received(reading)`. Those sensor events are always the same until the next api call updates the cache.

Only thing i did was remove the dictionary entry that just got read. so on additional calls of the same sensor an exception is thrown because the dictionary entry does not exist. This exception is immediately caught only skipping the `self.data_received(reading)` call.

the tricky part here is that the different sensors are called individually so one cannot remove the whole cache, only the entry inside the cache for the current sensor is removed.

Anyway, this solution results in one pair of SENSOR_UPDATE log entry per sensor per api call.

