### PR TITLE
Rssi and Interval sensors added

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,8 +50,10 @@ class iSpindel(SensorActive):
 				if cache[self.key] is not None:
 					if self.sensorType == "Gravity":
 						reading = calcGravity(self.tuningPolynom, cache[self.key]['Angle'], self.unitsGravity)
+						del cache[self.key]['Angle']
 					else:
 						reading = cache[self.key][self.sensorType]
+						del cache[self.key][self.sensorType]
 					self.data_received(reading)
 			except:
 				pass

--- a/__init__.py
+++ b/__init__.py
@@ -72,12 +72,12 @@ def set_temp():
 	temp = round(float(data["temperature"]), 2)
 	angle = data["angle"]
 	battery = data["battery"]
-
-	interval = data["interval"]
-	RSSI = data["RSSI"]
-
-	cache[id] = {'Temperature': temp, 'Angle': angle, 'Battery': battery, 'Interval': interval, 'RSSI': RSSI}
-
+	try: # this makes it compatible with VERY OLD iSpindel firmware
+		interval = data["interval"]
+		RSSI = data["RSSI"]
+		cache[id] = {'Temperature': temp, 'Angle': angle, 'Battery': battery, 'Interval': interval, 'RSSI': RSSI}
+	except:
+		cache[id] = {'Temperature': temp, 'Angle': angle, 'Battery': battery}
 	return ('', 204)
 
 @cbpi.initalizer()

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ def calcGravity(polynom, tilt, unitsGravity):
 @cbpi.sensor
 class iSpindel(SensorActive):
 	key = Property.Text(label="iSpindel Name", configurable=True, description="Enter the name of your iSpindel")
-	sensorType = Property.Select("Data Type", options=["Temperature", "Gravity", "Battery"], description="Select which type of data to register for this sensor")
+	sensorType = Property.Select("Data Type", options=["Temperature", "Gravity", "Battery", "Interval", "RSSI"], description="Select which type of data to register for this sensor")
 	tuningPolynom = Property.Text(label="Tuning Polynomial", configurable=True, default_value="tilt", description="Enter your iSpindel polynomial. Use the variable tilt for the angle reading from iSpindel. Does not support ^ character.")
 	unitsGravity = Property.Select("Gravity Units", options=["SG", "Brix", "°P"], description="Displays gravity reading with this unit if the Data Type is set to Gravity. Does not convert between units, to do that modify your polynomial.")
 
@@ -37,6 +37,10 @@ class iSpindel(SensorActive):
 			return self.unitsGravity
 		elif self.sensorType == "Battery":
 			return "V"
+		elif self.sensorType == "Interval":
+			return "s"
+		elif self.sensorType == "RSSI":
+			return "dB"
 		else:
 			return " "
 
@@ -62,14 +66,17 @@ class iSpindel(SensorActive):
 @blueprint.route('/api/hydrometer/v1/data', methods=['POST'])
 def set_temp():
 	global cache
-	
+	# example data: {u'angle': 83.50415, u'name': u'iSpindel', u'battery': 4.056309, u'interval': 10, u'gravity': 30.2962, u'temp_units': u'C', u'RSSI': -58, u'ID': 4549055, u'temperature': 16.25}
 	data = request.get_json()
 	id = data["name"]
 	temp = round(float(data["temperature"]), 2)
 	angle = data["angle"]
 	battery = data["battery"]
 
-	cache[id] = {'Temperature': temp, 'Angle': angle, 'Battery': battery}
+	interval = data["interval"]
+	RSSI = data["RSSI"]
+
+	cache[id] = {'Temperature': temp, 'Angle': angle, 'Battery': battery, 'Interval': interval, 'RSSI': RSSI}
 
 	return ('', 204)
 


### PR DESCRIPTION
![Screenshot from 2020-07-12 13-49-02](https://user-images.githubusercontent.com/61054729/87245566-95e83780-c446-11ea-8a16-83e8d39400bb.png)
Added RSSI and Interval as possible sensors. Since newer iSpindel firmware automatically provide these information. should also still work with VERY OLD iSpindel firmware where rssi and or interval is not send and will default back to old logic  with rssi and interval never getting any readings.

my other pull request is also part of this pull request (preventing logspam by cleaning up cache)